### PR TITLE
Add support for node process in Raycast 1.55

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "raycast",
   "displayName": "Raycast",
   "description": "",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "engines": {
     "vscode": "^1.67.0"
   },

--- a/src/assets.ts
+++ b/src/assets.ts
@@ -10,7 +10,7 @@ export async function getAssetsFromFolder(folder: string): Promise<string[]> {
 
 export async function getImageAssetsFromFolder(folder: string): Promise<string[]> {
   const files = (await getAssetsFromFolder(folder)).filter(
-    (f) => f.endsWith(".png") || f.endsWith("*.jpg") || f.endsWith(".gif") || f.endsWith(".svg")
+    (f) => f.endsWith(".png") || f.endsWith("*.jpg") || f.endsWith(".gif") || f.endsWith(".svg"),
   );
   return files;
 }

--- a/src/cmds.ts
+++ b/src/cmds.ts
@@ -43,20 +43,20 @@ export function registerAllCommands(manager: ExtensionManager) {
   manager.registerCommand("attachdebugger", async () => attachDebuggerCmd(manager));
   manager.registerCommand("refreshtree", async () => refreshTreeCmd(manager));
   manager.registerCommand("goto.preference", async (...args: any[]) =>
-    gotoPreferenceManifestLocationCmd(manager, args)
+    gotoPreferenceManifestLocationCmd(manager, args),
   );
   manager.registerCommand("goto.command", async (...args: any[]) => gotoCommandManifestLocationCmd(manager, args));
   manager.registerCommand("goto.command.mode", async (...args: any[]) =>
-    gotoCommandModeManifestLocationCmd(manager, args)
+    gotoCommandModeManifestLocationCmd(manager, args),
   );
   manager.registerCommand("goto.command.disabledbydefault", async (...args: any[]) =>
-    gotoCommandDisabledByDefaultManifestLocationCmd(manager, args)
+    gotoCommandDisabledByDefaultManifestLocationCmd(manager, args),
   );
   manager.registerCommand("goto.command.interval", async (...args: any[]) =>
-    gotoCommandIntervalManifestLocationCmd(manager, args)
+    gotoCommandIntervalManifestLocationCmd(manager, args),
   );
   manager.registerCommand("goto.command.argument", async (...args: any[]) =>
-    gotoCommandArgumentManifestLocationCmd(manager, args)
+    gotoCommandArgumentManifestLocationCmd(manager, args),
   );
   manager.registerCommand("command.arguments.add", async (...args: any[]) => addCommandArgumentCmd(manager, args));
 }

--- a/src/commands/attachdebugger.ts
+++ b/src/commands/attachdebugger.ts
@@ -8,7 +8,7 @@ async function getRaycastNodePid(manager: ExtensionManager): Promise<number | nu
     const { stdout, stderr } = await exec("ps -eo pid,command");
     const splits = stdout.split("\n") as string[];
     for (const s of splits) {
-      if (s.includes("Raycast.app") && s.includes("bin/node")) {
+      if (s.includes("Raycast Helper (Extensions)") || (s.includes("Raycast.app") && s.includes("bin/node"))) {
         manager.logger.debug(`found Raycast node process: ${s}`);
         const st = s.trim();
         const m = st.match(/([0-9]+)/g);
@@ -27,7 +27,7 @@ export async function attachDebuggerCmd(manager: ExtensionManager) {
   const pid = await getRaycastNodePid(manager);
   if (!pid) {
     throw Error(
-      "Could not get Raycast node process. Make sure Raycast is running and an extension was started at least once"
+      "Could not get Raycast node process. Make sure Raycast is running and an extension was started at least once",
     );
   }
   manager.logger.debug(`${pid}`);

--- a/src/commands/gotopreflocation.ts
+++ b/src/commands/gotopreflocation.ts
@@ -8,7 +8,7 @@ import { readManifestAST, readManifestFile } from "../manifest";
 async function getPreferencePositionInFile(
   filename: string,
   prefName: string,
-  cmdName?: string | undefined
+  cmdName?: string | undefined,
 ): Promise<vscode.Position | undefined> {
   try {
     const manifest = await readManifestAST(filename);

--- a/src/external/handler.ts
+++ b/src/external/handler.ts
@@ -87,7 +87,7 @@ async function processFileRequest(requestFilename: string, manager: ExtensionMan
     if (filename) {
       await handleWriteCommands(
         vscode.Uri.parse(`vscode://tonka3000.raycast/writecommands?filename=${filename}`),
-        manager
+        manager,
       );
     }
   } else {

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -28,7 +28,7 @@ export class ExtensionManager implements vscode.Disposable {
       vscode.workspace.onDidChangeConfiguration(async () => {
         this.logger.debug("config changed event");
         await this.updateState();
-      })
+      }),
     );
     this.registerPackageJsonChanges();
     this.registerCompletionProviders();
@@ -51,7 +51,7 @@ export class ExtensionManager implements vscode.Disposable {
     this._context.subscriptions.push(
       vscode.workspace.onDidCreateFiles((e) => {
         triggerUpdateOnChange(e.files.map((f) => f.fsPath));
-      })
+      }),
     );
     this._context.subscriptions.push(
       vscode.workspace.onDidRenameFiles((e) => {
@@ -61,7 +61,7 @@ export class ExtensionManager implements vscode.Disposable {
           files.push(f.oldUri.fsPath);
         });
         triggerUpdateOnChange(files);
-      })
+      }),
     );
     this._context.subscriptions.push(
       vscode.workspace.onDidChangeTextDocument((e) => {
@@ -69,12 +69,12 @@ export class ExtensionManager implements vscode.Disposable {
         if (e.document.fileName === pkgjson) {
           triggerUpdateOnChange([e.document.fileName]);
         }
-      })
+      }),
     );
     this._context.subscriptions.push(
       vscode.workspace.onDidDeleteFiles((e) => {
         triggerUpdateOnChange(e.files.map((f) => f.fsPath));
-      })
+      }),
     );
     this._context.subscriptions.push(
       vscode.workspace.onDidSaveTextDocument((e) => {
@@ -83,7 +83,7 @@ export class ExtensionManager implements vscode.Disposable {
           this.updateState();
           this.refreshTree();
         }
-      })
+      }),
     );
   }
 
@@ -308,7 +308,7 @@ export class ExtensionManager implements vscode.Disposable {
           document: vscode.TextDocument,
           position: vscode.Position,
           token: vscode.CancellationToken,
-          context: vscode.CompletionContext
+          context: vscode.CompletionContext,
         ) {
           const line = document.lineAt(position.line);
           const text = line.text.substring(0, position.character);
@@ -324,7 +324,7 @@ export class ExtensionManager implements vscode.Disposable {
         },
       },
       '"',
-      "'"
+      "'",
     );
     const jsonImageAssetCompletionProvider = vscode.languages.registerCompletionItemProvider(
       "json",
@@ -333,7 +333,7 @@ export class ExtensionManager implements vscode.Disposable {
           document: vscode.TextDocument,
           position: vscode.Position,
           token: vscode.CancellationToken,
-          context: vscode.CompletionContext
+          context: vscode.CompletionContext,
         ) {
           const filename = path.basename(document.fileName);
           if (filename !== "package.json") {
@@ -362,7 +362,7 @@ export class ExtensionManager implements vscode.Disposable {
           return undefined;
         },
       },
-      '"'
+      '"',
     );
     this._context.subscriptions.push(tsImageAssetCompletionProvider, jsonImageAssetCompletionProvider);
   }

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -158,7 +158,7 @@ function getObject(root: ValueNode, path: string): ValueNode | undefined {
           for (const c of cursor.children) {
             if (c.type === "Object") {
               const result = c.children.find(
-                (e) => e.key.value === key && e.value.type === "Literal" && e.value.value === val
+                (e) => e.key.value === key && e.value.type === "Literal" && e.value.value === val,
               );
               if (result) {
                 cursor = c;

--- a/src/npm.ts
+++ b/src/npm.ts
@@ -13,7 +13,7 @@ interface NPMResponse {
 
 export async function fetchVersionFromNPMPackage(
   manager: ExtensionManager,
-  packageName: string
+  packageName: string,
 ): Promise<string | undefined> {
   try {
     manager.logger.debug(`Fetch NPM package information for '${packageName}'`);

--- a/src/picker.ts
+++ b/src/picker.ts
@@ -7,7 +7,7 @@ export interface CustomQuickPickOptions {
 
 export async function showCustomQuickPick(
   choices: string[],
-  options?: CustomQuickPickOptions | undefined
+  options?: CustomQuickPickOptions | undefined,
 ): Promise<string> {
   return new Promise((resolve) => {
     const quickPick = vscode.window.createQuickPick();

--- a/src/tree.ts
+++ b/src/tree.ts
@@ -53,15 +53,15 @@ export class RaycastTreeDataProvider implements vscode.TreeDataProvider<RaycastT
         items.push(
           new MigrateTreeItem(
             latestMigration ? toMinorVersion(latestMigration, true) : "?",
-            localVersion ? reduceToVersion(localVersion) : "?"
-          )
+            localVersion ? reduceToVersion(localVersion) : "?",
+          ),
         );
       }
       items.push(
         ...[
           new CommandsTreeItem(vscode.TreeItemCollapsibleState.Expanded),
           new PreferencesTreeItem(vscode.TreeItemCollapsibleState.Collapsed),
-        ]
+        ],
       );
       return Promise.resolve(items);
     } else {
@@ -77,9 +77,9 @@ export class RaycastTreeDataProvider implements vscode.TreeDataProvider<RaycastT
                 this.manifest,
                 (c.preferences && c.preferences.length) || c.mode
                   ? vscode.TreeItemCollapsibleState.Collapsed
-                  : vscode.TreeItemCollapsibleState.None
-              )
-          )
+                  : vscode.TreeItemCollapsibleState.None,
+              ),
+          ),
         );
       } else if (element instanceof PreferencesTreeItem) {
         const cmd = element.cmd;
@@ -89,8 +89,8 @@ export class RaycastTreeDataProvider implements vscode.TreeDataProvider<RaycastT
         }
         return Promise.resolve(
           prefs.map(
-            (p) => new PreferenceTreeItem(p, this.manager, this.manifest, vscode.TreeItemCollapsibleState.None, cmd)
-          )
+            (p) => new PreferenceTreeItem(p, this.manager, this.manifest, vscode.TreeItemCollapsibleState.None, cmd),
+          ),
         );
       } else if (element instanceof CommandTreeItem) {
         const prefs = element.cmd?.preferences || [];
@@ -104,15 +104,15 @@ export class RaycastTreeDataProvider implements vscode.TreeDataProvider<RaycastT
         children.push(
           new PreferencesTreeItem(
             prefs.length > 0 ? vscode.TreeItemCollapsibleState.Expanded : vscode.TreeItemCollapsibleState.None,
-            element.cmd
-          )
+            element.cmd,
+          ),
         );
         const args = element.cmd?.arguments || [];
         children.push(
           new ArgumentsTreeItem(
             args.length > 0 ? vscode.TreeItemCollapsibleState.Expanded : vscode.TreeItemCollapsibleState.None,
-            element.cmd
-          )
+            element.cmd,
+          ),
         );
         const disabledByDefault = element.cmd?.disabledByDefault || false;
         if (disabledByDefault) {
@@ -124,8 +124,8 @@ export class RaycastTreeDataProvider implements vscode.TreeDataProvider<RaycastT
         const args = cmd?.arguments || [];
         return Promise.resolve(
           args.map(
-            (a) => new ArgumentTreeItem(a, this.manager, this.manifest, vscode.TreeItemCollapsibleState.None, cmd)
-          )
+            (a) => new ArgumentTreeItem(a, this.manager, this.manifest, vscode.TreeItemCollapsibleState.None, cmd),
+          ),
         );
       }
     }
@@ -134,7 +134,7 @@ export class RaycastTreeDataProvider implements vscode.TreeDataProvider<RaycastT
 
   private isRaycastAPIUpdateAvailable(
     raycastNPMVersion: string | undefined,
-    packageJSONVersion: string | undefined
+    packageJSONVersion: string | undefined,
   ): boolean {
     try {
       if (!raycastNPMVersion || !packageJSONVersion) {
@@ -143,7 +143,7 @@ export class RaycastTreeDataProvider implements vscode.TreeDataProvider<RaycastT
       const minorPackageJSON = toMinorVersion(reduceToVersion(packageJSONVersion));
       const minorNPM = toMinorVersion(raycastNPMVersion);
       this.manager.logger.debug(
-        `raycast npm Version: ${raycastNPMVersion}, package.json version: ${packageJSONVersion}`
+        `raycast npm Version: ${raycastNPMVersion}, package.json version: ${packageJSONVersion}`,
       );
       this.manager.logger.debug(`minor version => npm: ${minorNPM}, package.json: ${minorPackageJSON}`);
       return semver.gt(minorNPM, minorPackageJSON);
@@ -187,7 +187,10 @@ export class RaycastTreeDataProvider implements vscode.TreeDataProvider<RaycastT
 }
 
 export class RaycastTreeItem extends vscode.TreeItem {
-  constructor(public label?: string, public readonly collapsibleState?: vscode.TreeItemCollapsibleState) {
+  constructor(
+    public label?: string,
+    public readonly collapsibleState?: vscode.TreeItemCollapsibleState,
+  ) {
     super(label || "", collapsibleState);
   }
 }
@@ -219,7 +222,7 @@ export class CommandTreeItem extends RaycastTreeItem {
     public readonly cmd: Command,
     public readonly manager: ExtensionManager,
     public readonly manifest: Manifest | undefined,
-    public readonly collapsibleState: vscode.TreeItemCollapsibleState
+    public readonly collapsibleState: vscode.TreeItemCollapsibleState,
   ) {
     super(cmd.title || cmd.name || "?", collapsibleState);
     this.description = cmd.subtitle;
@@ -241,7 +244,10 @@ export class CommandTreeItem extends RaycastTreeItem {
 }
 
 export class PreferencesTreeItem extends RaycastTreeItem {
-  constructor(public readonly collapsibleState: vscode.TreeItemCollapsibleState, public readonly cmd?: Command) {
+  constructor(
+    public readonly collapsibleState: vscode.TreeItemCollapsibleState,
+    public readonly cmd?: Command,
+  ) {
     super("Preferences", collapsibleState);
     this.contextValue = cmd === undefined ? "preferences" : "command-preferences";
     this.iconPath = new vscode.ThemeIcon("gear");
@@ -249,7 +255,10 @@ export class PreferencesTreeItem extends RaycastTreeItem {
 }
 
 export class ArgumentsTreeItem extends RaycastTreeItem {
-  constructor(public readonly collapsibleState: vscode.TreeItemCollapsibleState, public readonly cmd?: Command) {
+  constructor(
+    public readonly collapsibleState: vscode.TreeItemCollapsibleState,
+    public readonly cmd?: Command,
+  ) {
     super("Arguments", collapsibleState);
     this.contextValue = "command-arguments";
     this.iconPath = new vscode.ThemeIcon("symbol-parameter");
@@ -312,7 +321,7 @@ export class PreferenceTreeItem extends RaycastTreeItem {
     public readonly manager: ExtensionManager,
     public readonly manifest: Manifest | undefined,
     public readonly collapsibleState: vscode.TreeItemCollapsibleState,
-    public readonly cmd?: Command
+    public readonly cmd?: Command,
   ) {
     super(preference.title || preference.name || "?", collapsibleState);
     if (preference.type === "checkbox") {
@@ -357,7 +366,7 @@ export class ArgumentTreeItem extends RaycastTreeItem {
     public readonly manager: ExtensionManager,
     public readonly manifest: Manifest | undefined,
     public readonly collapsibleState: vscode.TreeItemCollapsibleState,
-    public readonly cmd?: Command
+    public readonly cmd?: Command,
   ) {
     super(argument.name || "?", collapsibleState);
     this.iconPath = getArgumentThemeIcon(argument.type);


### PR DESCRIPTION
Since Raycast 1.55 the node process is called `Raycast Helper (Extensions)`. This is required to attach the debugger