### PR TITLE
Add extension issue dashboard command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## 0.13
+
+- Add `Open Extension Issues Dashboard`
+
+## 0.12
+
+- Add support for new Raycast node process
+
 ## 0.11
 
 - Display `disableByDefault` in tree

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ and more
 - ✅ Search in [Documentation](https://developers.raycast.com)
 - ✅ Raycast Tree-view for easy navigation
 - ✅ Auto Completion for script directives
+- ✅ Open the Extension Issues Dashboard
 
 ## Requirements
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "raycast",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "raycast",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "license": "MIT",
       "dependencies": {
         "edit-json-file": "^1.7.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "raycast",
   "displayName": "Raycast",
   "description": "",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "engines": {
     "vscode": "^1.67.0"
   },
@@ -82,6 +82,11 @@
       {
         "command": "raycast.searchdocs",
         "title": "Search Documentation",
+        "category": "Raycast"
+      },
+      {
+        "command": "raycast.extensionissues",
+        "title": "Open Extension Issues Dashboard",
         "category": "Raycast"
       },
       {
@@ -250,6 +255,10 @@
         },
         {
           "command": "raycast.goto.command.disabledbydefault",
+          "when": "raycast.workspaceEnabled"
+        },
+        {
+          "command": "raycast.extensionissues",
           "when": "raycast.workspaceEnabled"
         },
         {

--- a/src/cmds.ts
+++ b/src/cmds.ts
@@ -23,6 +23,7 @@ import { gotoCommandArgumentManifestLocationCmd } from "./commands/goto/argument
 import { addCommandArgumentCmd } from "./commands/addCommandArgument";
 import { updateInternalState } from "./commands/updateInternalState";
 import { gotoCommandDisabledByDefaultManifestLocationCmd } from "./commands/goto/disabledByDefault";
+import { extensionIssuesCmd } from "./commands/extensionIssues";
 
 export function registerAllCommands(manager: ExtensionManager) {
   manager.registerCommand("lint", async () => lintCmd(manager));
@@ -42,6 +43,7 @@ export function registerAllCommands(manager: ExtensionManager) {
   manager.registerCommand("publish", async () => publicCmd(manager));
   manager.registerCommand("attachdebugger", async () => attachDebuggerCmd(manager));
   manager.registerCommand("refreshtree", async () => refreshTreeCmd(manager));
+  manager.registerCommand("extensionissues", async () => extensionIssuesCmd(manager));
   manager.registerCommand("goto.preference", async (...args: any[]) =>
     gotoPreferenceManifestLocationCmd(manager, args),
   );

--- a/src/commands/extensionIssues.ts
+++ b/src/commands/extensionIssues.ts
@@ -1,0 +1,45 @@
+import * as vscode from "vscode";
+import { ExtensionManager } from "../manager";
+import path = require("path");
+import { Manifest, readManifestFile } from "../manifest";
+import { fileExists } from "../utils";
+import { fetchStoreListings } from "../store";
+
+async function getManifest(manager: ExtensionManager): Promise<Manifest | undefined> {
+  const ws = manager.getActiveWorkspace();
+  if (!ws) {
+    throw Error("No active workspace");
+  }
+  const pkgFilename = path.join(ws.uri.fsPath, "package.json");
+  if (await fileExists(pkgFilename)) {
+    return await readManifestFile(pkgFilename);
+  }
+  throw new Error("No manifest file found in current workspace");
+}
+
+async function getExtensionIdFromStore(extensionId: string, manager: ExtensionManager): Promise<string> {
+  const listings = await fetchStoreListings();
+  const extension = listings.data?.find((e) => e.name === extensionId);
+  const id = extension?.id;
+  if (!id) {
+    throw new Error(`Could not find the extension "${extensionId}" in the Raycast Store`);
+  }
+  return id;
+}
+
+export async function extensionIssuesCmd(manager: ExtensionManager) {
+  manager.logger.debug("Start Extension Issues");
+
+  const manifest = await getManifest(manager);
+  const extensionId = manifest?.name;
+  if (!extensionId) {
+    throw new Error("Could not get Extension Name");
+  }
+
+  manager.logger.debug(`Get Extension ID from store for "${extensionId}"`);
+  const storeId = await getExtensionIdFromStore(extensionId, manager);
+
+  const url = `https://www.raycast.com/extension-issues?extensionId=${storeId}`;
+
+  vscode.env.openExternal(vscode.Uri.parse(url));
+}

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,0 +1,16 @@
+import fetch from "node-fetch";
+
+interface StoreListingExtension {
+  id?: string;
+  name?: string;
+}
+
+interface StoreListings {
+  data?: StoreListingExtension[];
+}
+
+export async function fetchStoreListings(): Promise<StoreListings> {
+  const response = await fetch("https://www.raycast.com/api/v1/store_listings?per_page=2000&include_native=false");
+  const data = (await response.json()) as StoreListings;
+  return data;
+}


### PR DESCRIPTION
Add command `Open Extension Issues Dashboard` which open the current Extensions issues board.
This only works when the Extension is registered in the Raycast Store already.